### PR TITLE
fix bug

### DIFF
--- a/header.php
+++ b/header.php
@@ -149,6 +149,7 @@
 <body ontouchstart>
 	<!-- 头部/pjax -->
 	<div id="pjax-container">
+		<?php $this->header('commentReply=1'); ?>
 		<div id="header">
 			<div id="header-container">
 				<h2><?php $this->options->title(); ?></h2>


### PR DESCRIPTION
修复评论区错误: 点击回复按钮JS报错后, 无法将评论框定位到回复区