### PR TITLE
feat: 增加使用 fastly 和 gcore 的 jsDelivr CDN 服务

### DIFF
--- a/libs/G.class.php
+++ b/libs/G.class.php
@@ -240,6 +240,10 @@ class G
             return 'https://cdn.jsdelivr.net/gh/youranreus/G@v' . self::$version . '/' . $path;
         else if (self::$config['cdn'] == 'sourcestorage')
             return 'https://source.ahdark.com/typecho/theme/G-theme/' . self::$version . '/' . $path;
+        else if (self::$config['cdn'] == 'jsdfastly')
+            return 'https://fastly.jsdelivr.net/gh/youranreus/G@v' . self::$version . '/' . $path;
+        else if (self::$config['cdn'] == 'jsdgcore')
+            return 'https://gcore.jsdelivr.net/gh/youranreus/G@v' . self::$version . '/' . $path;
         else
             return self::$config['cdn'] . $path;
     }


### PR DESCRIPTION
## 更改内容

由于 cdn.jsdelivr.net 在中国大陆地区被 ~~神秘势力~~ 阻断，增加使用 fastly 和 gcore 的 jsDelivr CDN 服务

## 更改文件

libs/G.class.php

## 使用方法

在主题设置中「是否开启静态资源cdn加速」一栏中：

填入 `jsdfastly` 以使用 https://fastly.jsdelivr.net ，填入 `jsdgcore` 以使用 https://gcore.jsdelivr.net

------

此为应对 cdn.jsdelivr.net 被阻断的 **临时** 策略，fastly.jsdelivr.net 和 gcore.jsdelivr.net 可能也将于不久的将来被阻断，建议用户换用 AHdark sourcestorage 或使用本地资源解决此问题。